### PR TITLE
Change Korean and Japanese to Kiev pronunciation

### DIFF
--- a/rails/locale/ja.yml
+++ b/rails/locale/ja.yml
@@ -65,7 +65,7 @@ ja:
     "Bucharest": "ブカレスト"
     "Cairo": "カイロ"
     "Helsinki": "ヘルシンキ"
-    "Kyiv": "キエフ"
+    "Kyiv": "キーウ"
     "Riga": "リガ"
     "Sofia": "ソフィア"
     "Tallinn": "タリン"

--- a/rails/locale/ko.yml
+++ b/rails/locale/ko.yml
@@ -65,7 +65,7 @@ ko:
     "Bucharest": "부쿠레슈티"
     "Cairo": "카이로"
     "Helsinki": "헬싱키"
-    "Kyiv": "키예프"
+    "Kyiv": "키이우"
     "Riga": "리가"
     "Sofia": "소피아"
     "Tallinn": "탈린"


### PR DESCRIPTION
The standard pronunciation of "Kiev" has been changed to the Ukrainian style in Korea and Japan

- Korean
  - 키예프 → 키이우

- Japanese
  -  キエフ → キーウ
